### PR TITLE
Update Privacy Policy to disclose Sentry crash reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        run: npm test
+
+      - name: Upload test results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: test-results/
+          retention-days: 7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,15 +11,36 @@ permissions:
   id-token: write
 
 jobs:
-  deploy:
+  test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        run: npm test
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,7 @@ _site/
 
 # 11ty cache
 .11tycache/
+
+# Playwright
+test-results/
+playwright-report/

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "^3.0.0"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.58.2"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -271,6 +274,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://parloa.jfrog.io/artifactory/api/npm/parloa-npm/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sindresorhus/slugify": {
@@ -1618,6 +1637,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://parloa.jfrog.io/artifactory/api/npm/parloa-npm/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://parloa.jfrog.io/artifactory/api/npm/parloa-npm/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://parloa.jfrog.io/artifactory/api/npm/parloa-npm/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/please-upgrade-node": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
@@ -1632,6 +1698,7 @@
       "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
       "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "posthtml-parser": "^0.11.0",
         "posthtml-render": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -5,12 +5,16 @@
   "main": ".eleventy.js",
   "scripts": {
     "build": "eleventy",
-    "start": "eleventy --serve"
+    "start": "eleventy --serve",
+    "test": "playwright test"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "dependencies": {
     "@11ty/eleventy": "^3.0.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.58.2"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  webServer: {
+    command: "npx eleventy --serve --port=8080",
+    port: 8080,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: "http://localhost:8080",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { browserName: "chromium" },
+    },
+  ],
+});

--- a/src/privacy-policy.md
+++ b/src/privacy-policy.md
@@ -5,7 +5,7 @@ title: Privacy Policy
 
 # Privacy Policy for Jazz Jam Studio
 
-Last Updated: February 10, 2025
+Last Updated: March 5, 2026
 
 ## Introduction
 
@@ -16,7 +16,7 @@ Welcome to Jazz Jam Studio. We respect your privacy and are committed to protect
 ### Through the App
 
 - **Local Storage Data**: The app stores your preferences, settings, and practice data locally on your device. This data never leaves your device and we cannot access it.
-- **Optional Crash Reporting**: In future versions, you may be given the option to share crash reports to help improve the app. This will always be opt-in, and you'll be able to enable or disable it at any time.
+- **Crash Reporting via Sentry**: The app uses Sentry, a third-party error tracking service, to automatically collect crash reports and error data. This may include device information (device model, OS version), app state at the time of the error, and stack traces. No personally identifiable information is intentionally collected through Sentry.
 
 ### Through the Website
 
@@ -28,8 +28,8 @@ Welcome to Jazz Jam Studio. We respect your privacy and are committed to protect
 ### App Data
 
 - All app settings and user preferences are stored locally on your device
-- We do not collect, transmit, or store any personal data from the app on our servers
-- If crash reporting is implemented in the future, this data will only be collected with your explicit consent
+- We do not collect, transmit, or store any personal data from the app on our servers, except for crash and error data collected by Sentry
+- Crash and error data collected by Sentry is used solely to identify and fix bugs and improve app stability
 
 ### Website Data
 
@@ -45,6 +45,7 @@ We use the following third-party services:
 
 - **MailerLite**: Manages our email communications. When you provide your email, it will be processed according to MailerLite's privacy policy.
 - **Google Play Store**: Handles beta testing distribution and manages app downloads. Your interaction with the Play Store is governed by Google's privacy policy.
+- **Sentry**: Provides crash reporting and error tracking for the app. Sentry collects crash reports, device information (device model, OS version), and app state at the time of an error. This data is used to identify and fix bugs and improve app stability. No personally identifiable information is intentionally collected. For more details, see [Sentry's Privacy Policy](https://sentry.io/privacy/).
 
 ## Data Storage and Security
 

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Home page", () => {
+  test("has correct title", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveTitle(
+      "Jazz Jam Studio - Your Personal Jazz Practice Companion"
+    );
+  });
+
+  test("displays main heading", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible();
+  });
+
+  test("contains link to privacy policy", async ({ page }) => {
+    await page.goto("/");
+    const privacyLink = page.getByRole("link", { name: /privacy policy/i });
+    await expect(privacyLink).toBeVisible();
+    await expect(privacyLink).toHaveAttribute("href", /privacy-policy/);
+  });
+
+  test("contains link to license page", async ({ page }) => {
+    await page.goto("/");
+    const licenseLink = page.getByRole("link", { name: /license/i });
+    await expect(licenseLink).toBeVisible();
+    await expect(licenseLink).toHaveAttribute("href", /license/);
+  });
+});

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,27 +1,27 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("Home page", () => {
-  test("has correct title", async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto("/");
+  });
+
+  test("has correct title", async ({ page }) => {
     await expect(page).toHaveTitle(
       "Jazz Jam Studio - Your Personal Jazz Practice Companion"
     );
   });
 
   test("displays main heading", async ({ page }) => {
-    await page.goto("/");
     await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible();
   });
 
   test("contains link to privacy policy", async ({ page }) => {
-    await page.goto("/");
     const privacyLink = page.getByRole("link", { name: /privacy policy/i });
     await expect(privacyLink).toBeVisible();
     await expect(privacyLink).toHaveAttribute("href", /privacy-policy/);
   });
 
   test("contains link to license page", async ({ page }) => {
-    await page.goto("/");
     const licenseLink = page.getByRole("link", { name: /license/i });
     await expect(licenseLink).toBeVisible();
     await expect(licenseLink).toHaveAttribute("href", /license/);

--- a/tests/license.spec.ts
+++ b/tests/license.spec.ts
@@ -1,8 +1,11 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("License page", () => {
-  test("displays the page heading", async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto("/license/");
+  });
+
+  test("displays the page heading", async ({ page }) => {
     await expect(
       page.getByRole("heading", {
         name: "Third-Party Software Acknowledgments",
@@ -11,7 +14,6 @@ test.describe("License page", () => {
   });
 
   test("lists FluidSynth acknowledgment", async ({ page }) => {
-    await page.goto("/license/");
     await expect(page.locator("body")).toContainText("FluidSynth");
     await expect(page.locator("body")).toContainText(
       "GNU Lesser General Public License"
@@ -19,13 +21,11 @@ test.describe("License page", () => {
   });
 
   test("lists Leland Font acknowledgment", async ({ page }) => {
-    await page.goto("/license/");
     await expect(page.locator("body")).toContainText("Leland");
     await expect(page.locator("body")).toContainText("SIL Open Font License");
   });
 
   test("lists MuseScore soundfont acknowledgment", async ({ page }) => {
-    await page.goto("/license/");
     await expect(page.locator("body")).toContainText("MuseScore_General");
     await expect(page.locator("body")).toContainText("MIT License");
   });

--- a/tests/license.spec.ts
+++ b/tests/license.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("License page", () => {
+  test("displays the page heading", async ({ page }) => {
+    await page.goto("/license/");
+    await expect(
+      page.getByRole("heading", {
+        name: "Third-Party Software Acknowledgments",
+      })
+    ).toBeVisible();
+  });
+
+  test("lists FluidSynth acknowledgment", async ({ page }) => {
+    await page.goto("/license/");
+    await expect(page.locator("body")).toContainText("FluidSynth");
+    await expect(page.locator("body")).toContainText(
+      "GNU Lesser General Public License"
+    );
+  });
+
+  test("lists Leland Font acknowledgment", async ({ page }) => {
+    await page.goto("/license/");
+    await expect(page.locator("body")).toContainText("Leland");
+    await expect(page.locator("body")).toContainText("SIL Open Font License");
+  });
+
+  test("lists MuseScore soundfont acknowledgment", async ({ page }) => {
+    await page.goto("/license/");
+    await expect(page.locator("body")).toContainText("MuseScore_General");
+    await expect(page.locator("body")).toContainText("MIT License");
+  });
+});

--- a/tests/privacy-policy.spec.ts
+++ b/tests/privacy-policy.spec.ts
@@ -1,8 +1,11 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("Privacy Policy", () => {
-  test("displays the page heading", async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto("/privacy-policy/");
+  });
+
+  test("displays the page heading", async ({ page }) => {
     await expect(
       page.getByRole("heading", { name: "Privacy Policy for Jazz Jam Studio" })
     ).toBeVisible();
@@ -11,7 +14,6 @@ test.describe("Privacy Policy", () => {
   test("discloses Sentry crash reporting in data collection", async ({
     page,
   }) => {
-    await page.goto("/privacy-policy/");
     await expect(page.locator("body")).toContainText(
       "Crash Reporting via Sentry"
     );
@@ -23,7 +25,6 @@ test.describe("Privacy Policy", () => {
   test("states no PII is intentionally collected via Sentry", async ({
     page,
   }) => {
-    await page.goto("/privacy-policy/");
     await expect(page.locator("body")).toContainText(
       "No personally identifiable information is intentionally collected"
     );
@@ -32,7 +33,6 @@ test.describe("Privacy Policy", () => {
   test("lists Sentry in third-party services with privacy policy link", async ({
     page,
   }) => {
-    await page.goto("/privacy-policy/");
     const sentryLink = page.getByRole("link", {
       name: /sentry.*privacy policy/i,
     });
@@ -44,14 +44,12 @@ test.describe("Privacy Policy", () => {
   });
 
   test("lists all third-party services", async ({ page }) => {
-    await page.goto("/privacy-policy/");
     for (const service of ["MailerLite", "Google Play Store", "Sentry"]) {
       await expect(page.locator("body")).toContainText(service);
     }
   });
 
   test("explains Sentry data is used for bug fixing", async ({ page }) => {
-    await page.goto("/privacy-policy/");
     await expect(page.locator("body")).toContainText(
       "identify and fix bugs and improve app stability"
     );

--- a/tests/privacy-policy.spec.ts
+++ b/tests/privacy-policy.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Privacy Policy", () => {
+  test("displays the page heading", async ({ page }) => {
+    await page.goto("/privacy-policy/");
+    await expect(
+      page.getByRole("heading", { name: "Privacy Policy for Jazz Jam Studio" })
+    ).toBeVisible();
+  });
+
+  test("discloses Sentry crash reporting in data collection", async ({
+    page,
+  }) => {
+    await page.goto("/privacy-policy/");
+    await expect(page.locator("body")).toContainText(
+      "Crash Reporting via Sentry"
+    );
+    await expect(page.locator("body")).toContainText("crash reports");
+    await expect(page.locator("body")).toContainText("device information");
+    await expect(page.locator("body")).toContainText("stack traces");
+  });
+
+  test("states no PII is intentionally collected via Sentry", async ({
+    page,
+  }) => {
+    await page.goto("/privacy-policy/");
+    await expect(page.locator("body")).toContainText(
+      "No personally identifiable information is intentionally collected"
+    );
+  });
+
+  test("lists Sentry in third-party services with privacy policy link", async ({
+    page,
+  }) => {
+    await page.goto("/privacy-policy/");
+    const sentryLink = page.getByRole("link", {
+      name: /sentry.*privacy policy/i,
+    });
+    await expect(sentryLink).toBeVisible();
+    await expect(sentryLink).toHaveAttribute(
+      "href",
+      "https://sentry.io/privacy/"
+    );
+  });
+
+  test("lists all third-party services", async ({ page }) => {
+    await page.goto("/privacy-policy/");
+    for (const service of ["MailerLite", "Google Play Store", "Sentry"]) {
+      await expect(page.locator("body")).toContainText(service);
+    }
+  });
+
+  test("explains Sentry data is used for bug fixing", async ({ page }) => {
+    await page.goto("/privacy-policy/");
+    await expect(page.locator("body")).toContainText(
+      "identify and fix bugs and improve app stability"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Updated privacy policy to disclose Sentry crash reporting (data collected, purpose, no PII, link to Sentry's privacy policy)
- Added Playwright e2e test suite covering all 3 pages (14 tests)
- Added CI workflow to run tests on PRs to `main`
- Updated deploy workflow to gate on passing tests before deploying to GitHub Pages
- Bumped Node.js version from 18 to 22 in all workflows

Closes #24

## Test plan
- [x] All 14 Playwright e2e tests pass locally
- [ ] CI workflow runs on this PR
- [ ] Verify privacy policy page displays Sentry disclosure after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)