### PR TITLE
feat: add Plausible analytics tracking

### DIFF
--- a/src/_layouts/markdown.njk
+++ b/src/_layouts/markdown.njk
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{{ title }} - Jazz Jam Studio</title>
+    <!-- Privacy-friendly analytics by Plausible -->
+    <script async src="https://plausible.io/js/pa-6gVA4g1_BezmrRwhMYs_B.js"></script>
+    <script>
+      window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+      plausible.init()
+    </script>
     <style>
       /* Base styles matching your app theme */
       :root {

--- a/src/index.html
+++ b/src/index.html
@@ -39,6 +39,13 @@
     />
     <meta name="twitter:image" content="https://jazzjam.app/assets/screenshot-4.png" />
 
+    <!-- Privacy-friendly analytics by Plausible -->
+    <script async src="https://plausible.io/js/pa-6gVA4g1_BezmrRwhMYs_B.js"></script>
+    <script>
+      window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+      plausible.init()
+    </script>
+
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/tests/analytics.spec.ts
+++ b/tests/analytics.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Analytics tracking", () => {
+  const pages = [
+    { name: "home page", path: "/" },
+    { name: "privacy policy", path: "/privacy-policy/" },
+    { name: "license", path: "/license/" },
+  ];
+
+  for (const { name, path } of pages) {
+    test(`${name} includes Plausible analytics script`, async ({ page }) => {
+      await page.goto(path);
+      const script = page.locator(
+        'script[src="https://plausible.io/js/pa-6gVA4g1_BezmrRwhMYs_B.js"]'
+      );
+      await expect(script).toHaveCount(1);
+      await expect(script).toHaveAttribute("async", "");
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Integrate Plausible analytics across all pages (home, privacy policy, license)
- Add Playwright tests verifying the analytics script is present on every page

Closes #33

## Test plan
- [x] Analytics script tag is present on the home page
- [x] Analytics script tag is present on the privacy policy page
- [x] Analytics script tag is present on the license page
- [x] All 29 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)