### PR TITLE
Fix Learn More mobile layout

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -702,6 +702,14 @@
           display: inline;
         }
 
+        .app-showcase-section {
+          min-height: 90vh;
+        }
+
+        .phone-image {
+          max-height: 50vh;
+        }
+
         .form-container {
           width: 100%;
           max-width: 100%;

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -128,6 +128,15 @@ test.describe("Home page", () => {
       expect(Math.abs(badgeCenter - blockCenter)).toBeLessThan(5);
     });
 
+    test("Learn More section is shorter than 100vh to avoid Android browser controls overlap", async ({ page }) => {
+      const section = page.locator(".app-showcase-section");
+      const sectionBox = await section.boundingBox();
+      const viewportHeight = 812;
+
+      // Section should be less than 100vh so content isn't clipped by device controls
+      expect(sectionBox!.height).toBeLessThan(viewportHeight);
+    });
+
     test("beta signup CTA appears before form on mobile", async ({ page }) => {
       const form = page.locator(".form-container");
       const ctaContent = page.locator(".beta-signup-content");


### PR DESCRIPTION
## Summary
- Reduce `.app-showcase-section` min-height from 100vh to 90vh on mobile to prevent Android browser bottom controls from clipping content
- Reduce `.phone-image` max-height from 70vh to 50vh on mobile so stacked content fits within the reduced section height
- Add Playwright test verifying the section is shorter than 100vh on mobile

Closes #30

## Test plan
- [ ] Verify on Android Chrome that the Learn More section content is not clipped by bottom browser controls
- [ ] Verify phone image and text are both fully visible on mobile
- [ ] All 32 Playwright tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)