### PR TITLE
feat: publish Privacy Policy + Terms of Service pages (#41)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -958,6 +958,7 @@
     <footer>
       <div class="container">
         <a href="/privacy-policy">Privacy Policy</a>
+        <a href="/terms-of-service">Terms of Service</a>
         <a href="/license">License</a>
       </div>
     </footer>

--- a/src/privacy-policy.md
+++ b/src/privacy-policy.md
@@ -5,7 +5,7 @@ title: Privacy Policy
 
 # Privacy Policy for Jazz Jam Studio
 
-Last Updated: March 7, 2026
+Last Updated: June 14, 2026
 
 ## Introduction
 
@@ -17,6 +17,7 @@ Welcome to Jazz Jam Studio. We respect your privacy and are committed to protect
 
 - **Local Storage Data**: The app stores your preferences, settings, and practice data locally on your device. This data never leaves your device and we cannot access it.
 - **Crash Reporting via Sentry**: The app uses Sentry, a third-party error tracking service, to automatically collect crash reports and error data. This may include device information (device model, OS version), app state at the time of the error, and stack traces. No personally identifiable information is intentionally collected through Sentry.
+- **In-App Purchases via RevenueCat**: When you make an in-app purchase (such as the Pro Unlock), the app uses RevenueCat, a third-party purchase-management service, to validate and manage your purchase. RevenueCat processes purchase receipts, an anonymous app user ID, and device data (such as platform, device model, and country) needed to verify entitlements and restore purchases. We use this data solely to grant and restore access to purchased features. We do not receive your payment card details — those are handled by the app store (Google Play or Apple App Store).
 
 ### Through the Website
 
@@ -46,12 +47,13 @@ We use the following third-party services:
 - **MailerLite**: Manages our email communications. When you provide your email, it will be processed according to MailerLite's privacy policy.
 - **Google Play Store**: Handles beta testing distribution and manages app downloads. Your interaction with the Play Store is governed by Google's privacy policy.
 - **Sentry**: Provides crash reporting and error tracking for the app. Sentry collects crash reports, device information (device model, OS version), and app state at the time of an error. This data is used to identify and fix bugs and improve app stability. No personally identifiable information is intentionally collected. For more details, see [Sentry's Privacy Policy](https://sentry.io/privacy/).
+- **RevenueCat**: Manages in-app purchases and subscriptions for the app. RevenueCat collects purchase receipts, an anonymous app user ID, and device data used to validate purchases and restore entitlements. This data is used solely to deliver and restore the features you have purchased. For more details, see [RevenueCat's Privacy Policy](https://www.revenuecat.com/privacy/).
 - **Plausible Analytics**: Provides privacy-friendly website analytics. Plausible does not use cookies, does not track users across sites, and does not collect personally identifiable information. All data is aggregated and no individual visitor profiles are created. For more details, see [Plausible's Privacy Policy](https://plausible.io/privacy).
 
 ## Data Storage and Security
 
 - App data is stored locally on your device
-- Website data (email addresses) is stored securely by our third-party providers (Mailchimp and Google)
+- Website data (email addresses) is stored securely by our third-party providers (MailerLite and Google)
 - We do not maintain any databases with user information
 
 ## Your Rights
@@ -62,6 +64,18 @@ You have the right to:
 - Request deletion of your email address from our mailing list
 - Manage your beta testing participation through Google Play Store
 - Control app permissions through your device settings
+
+### Your Rights Under the GDPR (EU/EEA Users)
+
+If you are located in the European Union or European Economic Area, the General Data Protection Regulation (GDPR) grants you the following rights over your personal data:
+
+- **Right of access**: request confirmation of whether we process your personal data and a copy of that data
+- **Right to rectification**: request correction of inaccurate or incomplete personal data
+- **Right to erasure ("right to be forgotten")**: request deletion of your personal data
+- **Right to restrict or object to processing**: request that we limit or stop processing your personal data
+- **Right to data portability**: request a copy of your data in a portable format
+
+Because most app data is stored locally on your device and we do not maintain user databases, the personal data we can act on is limited to your email address (for website/beta communications) and purchase records held by our purchase provider. To exercise any of these rights, contact us at support@jazzjam.app and we will respond within the timeframes required by law.
 
 ## Children's Privacy
 

--- a/src/terms-of-service.md
+++ b/src/terms-of-service.md
@@ -1,0 +1,61 @@
+---
+layout: markdown.njk
+title: Terms of Service
+---
+
+# Terms of Service for Jazz Jam Studio
+
+Last Updated: June 14, 2026
+
+## Introduction
+
+These Terms of Service ("Terms") govern your use of the Jazz Jam Studio mobile application ("App") and website ("Website"), operated by Jazz Jam Studio ("we", "us", or "our"). By downloading, installing, or using the App, you agree to be bound by these Terms. If you do not agree, do not use the App.
+
+## Licence to Use the App
+
+Subject to your compliance with these Terms, we grant you a personal, non-transferable, non-exclusive, revocable licence to download and use the App on devices you own or control, solely for your own personal, non-commercial use.
+
+You may not:
+
+- Copy, modify, distribute, sell, or lease any part of the App
+- Reverse engineer or attempt to extract the source code of the App, except where this restriction is prohibited by applicable law
+- Use the App in any way that is unlawful or that infringes the rights of others
+
+This licence does not transfer any ownership of the App to you. All intellectual property rights in the App remain with us and our licensors.
+
+## In-App Purchases
+
+The App offers an optional one-time in-app purchase, "Pro Unlock", which permanently unlocks additional features for the account or device on which it is purchased.
+
+- **Pro Unlock is a one-time purchase**, not a subscription. It does not auto-renew and you will not be charged on a recurring basis for it.
+- Purchases are processed by the platform's app store (Google Play or, where available, the Apple App Store), not by us directly. Your purchase is also subject to the applicable app store's terms.
+- Once unlocked, Pro features remain available on the purchasing account, subject to the app store's terms and your continued ability to access that account.
+
+## Refunds and Restoring Purchases
+
+- **Refunds** for in-app purchases are handled by the app store through which you made the purchase. Google Play and Apple App Store refund policies are the governing authority for any refund request; please refer to and follow their respective processes.
+- **Restoring purchases**: if you reinstall the App or switch to a new device using the same app store account, you can restore your Pro Unlock at no additional cost using the "Restore Purchases" option in the App.
+
+## Disclaimer of Warranties
+
+The App is provided "as is" and "as available" without warranties of any kind, whether express or implied, including but not limited to implied warranties of merchantability, fitness for a particular purpose, and non-infringement. We do not warrant that the App will be uninterrupted, error-free, or free of harmful components, or that defects will be corrected.
+
+Nothing in these Terms limits or excludes any rights you may have as a consumer under applicable mandatory law that cannot lawfully be excluded.
+
+## Limitation of Liability
+
+To the maximum extent permitted by applicable law, we will not be liable for any indirect, incidental, special, consequential, or punitive damages, or any loss of data, profits, or revenue, arising out of or related to your use of (or inability to use) the App, even if we have been advised of the possibility of such damages.
+
+To the maximum extent permitted by applicable law, our total liability for any claims arising out of or related to these Terms or the App will not exceed the amount you paid us, if any, for the App in the twelve months preceding the claim.
+
+## Governing Law
+
+These Terms are governed by and construed in accordance with the laws of Spain, without regard to its conflict-of-law provisions. Any disputes arising under these Terms will be subject to the competent courts of Spain, without prejudice to any mandatory consumer protection rights available to you in your country of residence.
+
+## Changes to These Terms
+
+We may update these Terms from time to time. We will notify you of any material changes by posting the updated Terms on this page and updating the "Last Updated" date above. Your continued use of the App after changes take effect constitutes acceptance of the revised Terms.
+
+## Contact Us
+
+For any questions about these Terms, please contact us at support@jazzjam.app.

--- a/tests/privacy-policy.spec.ts
+++ b/tests/privacy-policy.spec.ts
@@ -44,9 +44,54 @@ test.describe("Privacy Policy", () => {
   });
 
   test("lists all third-party services", async ({ page }) => {
-    for (const service of ["MailerLite", "Google Play Store", "Sentry", "Plausible"]) {
+    for (const service of [
+      "MailerLite",
+      "Google Play Store",
+      "Sentry",
+      "Plausible",
+      "RevenueCat",
+    ]) {
       await expect(page.locator("body")).toContainText(service);
     }
+  });
+
+  test("discloses RevenueCat in-app purchase data collection", async ({
+    page,
+  }) => {
+    await expect(page.locator("body")).toContainText(
+      "In-App Purchases via RevenueCat"
+    );
+    await expect(page.locator("body")).toContainText("purchase receipts");
+    await expect(page.locator("body")).toContainText("anonymous app user ID");
+  });
+
+  test("lists RevenueCat in third-party services with privacy policy link", async ({
+    page,
+  }) => {
+    const revenueCatLink = page.getByRole("link", {
+      name: /revenuecat.*privacy policy/i,
+    });
+    await expect(revenueCatLink).toBeVisible();
+    await expect(revenueCatLink).toHaveAttribute(
+      "href",
+      "https://www.revenuecat.com/privacy/"
+    );
+  });
+
+  test("covers GDPR rights for EU users with a contact route", async ({
+    page,
+  }) => {
+    await expect(page.locator("body")).toContainText(
+      "Your Rights Under the GDPR"
+    );
+    for (const right of [
+      "Right of access",
+      "Right to rectification",
+      "Right to erasure",
+    ]) {
+      await expect(page.locator("body")).toContainText(right);
+    }
+    await expect(page.locator("body")).toContainText("support@jazzjam.app");
   });
 
   test("discloses Plausible analytics on the website", async ({ page }) => {

--- a/tests/terms-of-service.spec.ts
+++ b/tests/terms-of-service.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Terms of Service", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/terms-of-service/");
+  });
+
+  test("displays the page heading", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", {
+        name: "Terms of Service for Jazz Jam Studio",
+      })
+    ).toBeVisible();
+  });
+
+  test("includes a last updated date", async ({ page }) => {
+    await expect(page.locator("body")).toContainText("Last Updated");
+  });
+
+  test("grants a personal, non-transferable licence to use the app", async ({
+    page,
+  }) => {
+    await expect(page.locator("body")).toContainText("Licence to Use the App");
+    await expect(page.locator("body")).toContainText("personal");
+    await expect(page.locator("body")).toContainText("non-transferable");
+  });
+
+  test("describes Pro Unlock as a one-time in-app purchase", async ({
+    page,
+  }) => {
+    await expect(page.locator("body")).toContainText("In-App Purchases");
+    await expect(page.locator("body")).toContainText("Pro Unlock");
+    await expect(page.locator("body")).toContainText("one-time");
+  });
+
+  test("references app store refund and restore-purchases policies", async ({
+    page,
+  }) => {
+    await expect(page.locator("body")).toContainText(
+      "Refunds and Restoring Purchases"
+    );
+    await expect(page.locator("body")).toContainText("Google Play");
+    await expect(page.locator("body")).toContainText("Restore Purchases");
+  });
+
+  test("includes limitation of liability and governing law clauses", async ({
+    page,
+  }) => {
+    await expect(page.locator("body")).toContainText("Limitation of Liability");
+    await expect(page.locator("body")).toContainText("Governing Law");
+    await expect(page.locator("body")).toContainText("laws of Spain");
+  });
+
+  test("provides a contact email", async ({ page }) => {
+    await expect(page.locator("body")).toContainText("support@jazzjam.app");
+  });
+
+  test("has no horizontal scroll at a 375x812 mobile viewport", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto("/terms-of-service/");
+    const hasHorizontalScroll = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth
+    );
+    expect(hasHorizontalScroll).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Publishes the stable, compliant legal pages on `jazzjam.app` required to unblock the Pro Unlock monetisation flow (Google Play requires a Privacy Policy URL; a ToS/EULA is required by Apple for subscriptions and recommended by Google for in-app billing disclosure).

- **New Terms of Service / EULA** at `/terms-of-service/` — personal, non-transferable app licence; Pro Unlock as a **one-time** in-app purchase; refunds/restore-purchases deferred to Google Play / Apple policies; disclaimer + limitation of liability; **Spain** governing law; last-updated date. Added to the homepage footer.
- **Privacy Policy update** — adds the **RevenueCat** disclosure (purchase receipts, anonymous app user ID, device data) plus a third-party-services entry; expands user rights with an explicit **GDPR** section (access, rectification, erasure, restriction, portability) and a `support@jazzjam.app` contact route; fixes a stale "Mailchimp" reference (provider is MailerLite); bumps the last-updated date.

### Decisions
- ToS URL: `/terms-of-service/`
- Pro Unlock product type: **one-time IAP** (per Play Console)
- Governing law: **Spain**

## Test plan

- `npm test` — full Playwright suite green (**43 passed**), including:
  - 8 new ToS specs (heading, licence, one-time IAP, refund/restore, liability + governing law, contact, and a **375×812 no-horizontal-scroll** mobile check)
  - 4 new Privacy Policy specs (RevenueCat disclosure + privacy-policy link, GDPR rights + contact route)
- Manual: pages render at `/privacy-policy/` and `/terms-of-service/` with no horizontal scroll at 375px width.

> Live HTTP-200 verification on `jazzjam.app` (clean public browser) holds once this merges and GitHub Pages redeploys.

## Follow-ups
- Pin the final URLs in issue #41's `## Final URLs` section once live on `main`, so the consumer side (amypellegrini/musicpracticepro#348) adopts them without drift.

Closes #41