### PR TITLE
feat: redesign home page for post production release

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -753,7 +753,11 @@
               productive and fun!
             </p>
             <div class="cta-block sm-flex-column">
-              <a href="#beta-program" class="primary-cta">Get the app</a>
+              <a
+                href="https://play.google.com/store/apps/details?id=com.musicpracticepro&amp;utm_source=emea_Med"
+                class="primary-cta"
+                >Get the app</a
+              >
               <a href="#learn-more" class="secondary-cta">Learn more</a>
               <img
                 class="google-play-badge"

--- a/src/index.html
+++ b/src/index.html
@@ -865,7 +865,7 @@
           <div class="form-container">
             <h4>Stay in the loop</h4>
             <p class="form-description">
-              We'll send instructions to your email.
+              We'll send a confirmation link to your email.
             </p>
             <form id="beta-signup-form">
               <input
@@ -952,7 +952,7 @@
                     <p>Give us an email and hit subscribe</p>
                   </li>
                   <li>
-                    <p>Check your email for instructions</p>
+                    <p>Check your email to confirm</p>
                   </li>
                   <li>
                     <p>Don't forget to check your spam folder!</p>

--- a/src/index.html
+++ b/src/index.html
@@ -239,6 +239,11 @@
 
       .hero .google-play-badge {
         height: 46px;
+        display: block;
+      }
+
+      .hero .google-play-badge img {
+        height: 100%;
         width: auto;
         display: block;
       }
@@ -759,11 +764,15 @@
                 >Get the app</a
               >
               <a href="#learn-more" class="secondary-cta">Learn more</a>
-              <img
+              <a
+                href="https://play.google.com/store/apps/details?id=com.musicpracticepro&amp;utm_source=emea_Med"
                 class="google-play-badge"
-                src="assets/GetItOnGooglePlay_Badge_Web_color_English.png"
-                alt="Available on Android"
-              />
+              >
+                <img
+                  src="assets/GetItOnGooglePlay_Badge_Web_color_English.png"
+                  alt="Available on Android"
+                />
+              </a>
             </div>
           </div>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -753,7 +753,7 @@
               productive and fun!
             </p>
             <div class="cta-block sm-flex-column">
-              <a href="#beta-program" class="primary-cta">Join our beta</a>
+              <a href="#beta-program" class="primary-cta">Get the app</a>
               <a href="#learn-more" class="secondary-cta">Learn more</a>
               <img
                 class="google-play-badge"
@@ -850,7 +850,7 @@
           style="gap: 2rem"
         >
           <div class="form-container">
-            <h4>Join our beta</h4>
+            <h4>Stay in the loop</h4>
             <p class="form-description">
               We'll send instructions to your email.
             </p>
@@ -918,10 +918,10 @@
           </div>
           <div class="beta-signup-content">
             <div class="max-w-400 margin-auto">
-              <h2>Get the app before it's launched!</h2>
+              <h2>Never miss an update</h2>
               <p class="mb-1">
-                Join the waitlist to get early access to the Jazz Jam app and
-                help us shape the future of jazz practice.
+                Subscribe to get news, tips, and updates about the Jazz Jam
+                app.
               </p>
               <div class="flex-row">
                 <svg

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -53,6 +53,14 @@ test.describe("Home page", () => {
     expect(bodyText).not.toMatch(/waitlist/i);
   });
 
+  test("hero primary CTA links to the live store listing", async ({ page }) => {
+    const primaryCta = page.locator(".primary-cta");
+    await expect(primaryCta).toHaveAttribute(
+      "href",
+      "https://play.google.com/store/apps/details?id=com.musicpracticepro&utm_source=emea_Med"
+    );
+  });
+
   test("contains link to privacy policy", async ({ page }) => {
     const privacyLink = page.getByRole("link", { name: /privacy policy/i });
     await expect(privacyLink).toBeVisible();

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -61,6 +61,15 @@ test.describe("Home page", () => {
     );
   });
 
+  test("Google Play badge is a clickable link to the store listing", async ({ page }) => {
+    const badgeLink = page.locator("a.google-play-badge");
+    await expect(badgeLink).toHaveAttribute(
+      "href",
+      "https://play.google.com/store/apps/details?id=com.musicpracticepro&utm_source=emea_Med"
+    );
+    await expect(badgeLink.locator("img")).toBeVisible();
+  });
+
   test("contains link to privacy policy", async ({ page }) => {
     const privacyLink = page.getByRole("link", { name: /privacy policy/i });
     await expect(privacyLink).toBeVisible();

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -38,12 +38,19 @@ test.describe("Home page", () => {
 
   test("displays beta signup section", async ({ page }) => {
     await expect(
-      page.getByRole("heading", { name: "Join our beta" })
+      page.getByRole("heading", { name: "Stay in the loop" })
     ).toBeVisible();
     await expect(page.getByLabel("email")).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Subscribe" })
     ).toBeVisible();
+  });
+
+  test("no pre-launch beta/waitlist copy remains", async ({ page }) => {
+    const bodyText = await page.locator("body").innerText();
+    expect(bodyText).not.toMatch(/join our beta/i);
+    expect(bodyText).not.toMatch(/get the app before it'?s launched/i);
+    expect(bodyText).not.toMatch(/waitlist/i);
   });
 
   test("contains link to privacy policy", async ({ page }) => {

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -53,6 +53,16 @@ test.describe("Home page", () => {
     expect(bodyText).not.toMatch(/waitlist/i);
   });
 
+  test("subscribe form copy reflects a news/updates confirmation flow, not waitlist instructions", async ({ page }) => {
+    await expect(page.locator(".form-description")).toHaveText(
+      "We'll send a confirmation link to your email."
+    );
+
+    const steps = page.locator(".beta-signup-steps");
+    await expect(steps).toContainText("Check your email to confirm");
+    await expect(steps).not.toContainText(/instructions/i);
+  });
+
   test("hero primary CTA links to the live store listing", async ({ page }) => {
     const primaryCta = page.locator(".primary-cta");
     await expect(primaryCta).toHaveAttribute(


### PR DESCRIPTION
## Summary
Redesigns the home page for post-production release by removing pre-launch beta/waitlist copy and updating CTAs to reflect the live app availability. Includes:
- Removed pre-launch beta/waitlist messaging
- Updated hero primary CTA to link to live store listing
- Made Google Play badge a clickable link
- Reworded subscribe form copy to news confirmation

Closes #32