### PR TITLE
feat: render Pro Unlock section from _data/shared.json

### DIFF
--- a/src/_data/shared.json
+++ b/src/_data/shared.json
@@ -1,0 +1,29 @@
+{
+  "__generated": "GENERATED from content/shared.json in the JazzJam workbench — do not edit. Regenerate: npm run sync",
+  "paywall": {
+    "title": "Unlock Pro",
+    "subtitle": "Export your backing tracks",
+    "benefits": [
+      {
+        "glyph": "MID",
+        "name": "MIDI",
+        "description": "Edit tracks in your DAW"
+      },
+      {
+        "glyph": "WAV",
+        "name": "WAV",
+        "description": "Uncompressed studio audio"
+      },
+      {
+        "glyph": "MP3",
+        "name": "MP3",
+        "description": "Small files, easy to share"
+      },
+      {
+        "glyph": "MXL",
+        "name": "MusicXML",
+        "description": "Open in MuseScore, Dorico, Finale"
+      }
+    ]
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -957,33 +957,23 @@
 
       <section class="pro-unlock">
         <div class="container">
-          <h2 class="text-center">Unlock Pro</h2>
+          <h2 class="text-center">{{ shared.paywall.title }}</h2>
           <p class="pro-unlock-subtitle text-center">
-            Export your backing tracks
+            {{ shared.paywall.subtitle }}
           </p>
           <div class="pro-unlock-grid">
+            {% for benefit in shared.paywall.benefits %}
             <div class="pro-unlock-feature">
-              <h3 class="pro-unlock-glyph">MIDI</h3>
-              <p>Edit tracks in your DAW</p>
+              <h3 class="pro-unlock-glyph">{{ benefit.name }}</h3>
+              <p>{{ benefit.description }}</p>
             </div>
-            <div class="pro-unlock-feature">
-              <h3 class="pro-unlock-glyph">WAV</h3>
-              <p>Uncompressed studio audio</p>
-            </div>
-            <div class="pro-unlock-feature">
-              <h3 class="pro-unlock-glyph">MP3</h3>
-              <p>Small files, easy to share</p>
-            </div>
-            <div class="pro-unlock-feature">
-              <h3 class="pro-unlock-glyph">MusicXML</h3>
-              <p>Open in MuseScore, Dorico, Finale</p>
-            </div>
+            {% endfor %}
           </div>
           <div class="pro-unlock-actions">
             <a
               href="https://play.google.com/store/apps/details?id=com.musicpracticepro&amp;utm_source=emea_Med"
               class="pro-unlock-cta"
-              >Unlock Pro</a
+              >{{ shared.paywall.title }}</a
             >
           </div>
         </div>


### PR DESCRIPTION
The Pro Unlock section (title, subtitle, benefit cards, CTA label) now renders from `src/_data/shared.json` via Nunjucks, instead of hardcoded HTML.

That data file is **generated** from the canonical `content/shared.json` in the private `jazzjam-workbench` repo, which also generates the app's paywall `benefits.ts` (amypellegrini/musicpracticepro#661) — single source of truth for the Pro feature matrix.

Rendered output is unchanged apart from whitespace (verified by diffing `_site/index.html` before/after); the full Playwright suite passes, including the no-hardcoded-pricing guardrail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)