### PR TITLE
fix: improve home page layout for tablet devices

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -718,8 +718,9 @@
         display: none;
       }
 
-      /* Tablet */
-      @media (max-width: 1024px) {
+      /* Tablet — 1199px covers large tablets in landscape
+         (e.g. iPad Pro 11" at 1194px) while staying below desktop. */
+      @media (max-width: 1199px) {
         .hero .hero-image {
           opacity: 0.5;
         }

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -325,6 +325,30 @@ test.describe("Home page", () => {
             expect(box!.x + box!.width).toBeLessThanOrEqual(width);
           }
         });
+
+        test("hero text and CTA fit the viewport and sit over a dimmed hero image", async ({
+          page,
+        }) => {
+          for (const selector of [
+            ".hero-content h1",
+            ".hero p.tagline",
+            ".primary-cta",
+          ]) {
+            const box = await page.locator(`${selector}:visible`).boundingBox();
+            expect(box, `${selector} should render`).not.toBeNull();
+            expect(box!.x, `${selector} left edge`).toBeGreaterThanOrEqual(0);
+            expect(
+              box!.x + box!.width,
+              `${selector} right edge`
+            ).toBeLessThanOrEqual(width);
+          }
+
+          // The hero artwork must be dimmed so the text stays readable over it.
+          const heroImageOpacity = await page
+            .locator(".hero-image")
+            .evaluate((el) => parseFloat(getComputedStyle(el).opacity));
+          expect(heroImageOpacity, "hero image opacity").toBeLessThan(1);
+        });
       });
     }
   });

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -349,6 +349,19 @@ test.describe("Home page", () => {
             .evaluate((el) => parseFloat(getComputedStyle(el).opacity));
           expect(heroImageOpacity, "hero image opacity").toBeLessThan(1);
         });
+
+        test("primary CTAs meet the 44px minimum touch-target height", async ({
+          page,
+        }) => {
+          for (const selector of [".primary-cta", ".pro-unlock-cta"]) {
+            const box = await page.locator(selector).boundingBox();
+            expect(box, `${selector} should render`).not.toBeNull();
+            expect(
+              box!.height,
+              `${selector} height`
+            ).toBeGreaterThanOrEqual(44);
+          }
+        });
       });
     }
   });

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -231,6 +231,55 @@ test.describe("Home page", () => {
     });
   });
 
+  test.describe("tablet layout", () => {
+    // Reference tablet viewports from issue #35.
+    const tabletViewports = [
+      { name: "iPad Mini portrait", width: 768, height: 1024 },
+      { name: "iPad Air portrait", width: 820, height: 1180 },
+      { name: "iPad Mini landscape", width: 1024, height: 768 },
+      { name: "iPad Air landscape", width: 1180, height: 820 },
+    ];
+
+    const topLevelSections = [
+      ".hero",
+      ".app-showcase-section",
+      ".features",
+      ".pro-unlock",
+      ".beta-signup",
+      "footer",
+    ];
+
+    for (const { name, width, height } of tabletViewports) {
+      test.describe(`${name} (${width}x${height})`, () => {
+        test.beforeEach(async ({ page }) => {
+          await page.setViewportSize({ width, height });
+          await page.goto("/");
+        });
+
+        test("page does not scroll horizontally and every section fits the viewport", async ({
+          page,
+        }) => {
+          const hasHorizontalScroll = await page.evaluate(
+            () =>
+              document.documentElement.scrollWidth >
+              document.documentElement.clientWidth
+          );
+          expect(hasHorizontalScroll).toBe(false);
+
+          for (const selector of topLevelSections) {
+            const box = await page.locator(selector).boundingBox();
+            expect(box, `${selector} should render`).not.toBeNull();
+            expect(box!.x, `${selector} left edge`).toBeGreaterThanOrEqual(0);
+            expect(
+              box!.x + box!.width,
+              `${selector} right edge`
+            ).toBeLessThanOrEqual(width);
+          }
+        });
+      });
+    }
+  });
+
   test.describe("Pro Unlock section responsiveness", () => {
     const viewports = [
       { name: "desktop", width: 1280, height: 800 },

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -300,6 +300,31 @@ test.describe("Home page", () => {
             expect(box!.x + box!.width).toBeLessThanOrEqual(width);
           }
         });
+
+        test("Pro Unlock benefit cards render two or more per row without overflow", async ({
+          page,
+        }) => {
+          const columnCount = await page
+            .locator(".pro-unlock-grid")
+            .evaluate(
+              (el) =>
+                getComputedStyle(el).gridTemplateColumns.split(" ").length
+            );
+          expect(
+            columnCount,
+            "pro unlock grid columns"
+          ).toBeGreaterThanOrEqual(2);
+
+          const cards = page.locator(".pro-unlock-feature");
+          const count = await cards.count();
+          expect(count).toBeGreaterThan(0);
+          for (let i = 0; i < count; i++) {
+            const box = await cards.nth(i).boundingBox();
+            expect(box).not.toBeNull();
+            expect(box!.x).toBeGreaterThanOrEqual(0);
+            expect(box!.x + box!.width).toBeLessThanOrEqual(width);
+          }
+        });
       });
     }
   });

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -276,6 +276,30 @@ test.describe("Home page", () => {
             ).toBeLessThanOrEqual(width);
           }
         });
+
+        test("features cards render in a multi-column layout without overflow", async ({
+          page,
+        }) => {
+          const columnCount = await page
+            .locator(".features-grid")
+            .evaluate(
+              (el) =>
+                getComputedStyle(el).gridTemplateColumns.split(" ").length
+            );
+          expect(columnCount, "features grid columns").toBeGreaterThanOrEqual(
+            2
+          );
+
+          const cards = page.locator(".feature-card");
+          const count = await cards.count();
+          expect(count).toBeGreaterThan(0);
+          for (let i = 0; i < count; i++) {
+            const box = await cards.nth(i).boundingBox();
+            expect(box).not.toBeNull();
+            expect(box!.x).toBeGreaterThanOrEqual(0);
+            expect(box!.x + box!.width).toBeLessThanOrEqual(width);
+          }
+        });
       });
     }
   });


### PR DESCRIPTION
Closes #35

## Summary

Covers the home page's tablet experience (768–1024px+, portrait and landscape) with Playwright viewport tests, and fixes the one real defect found: the hero dim treatment stopped at 1024px, so large tablets in landscape (1180×820, iPad Pro 11" at 1194px) rendered the hero text over an undimmed image.

- `src/index.html`: widen the tablet media query from `max-width: 1024px` to `max-width: 1199px` so the hero image stays dimmed (and legible text) on large tablets in landscape, while staying below the 1280px desktop layout.
- `tests/index.spec.ts`: new `tablet layout` suite looping the four reference viewports from #35 (768×1024, 820×1180, 1024×768, 1180×820), asserting per AC:
  - AC1 — no horizontal scroll; every top-level section fits the viewport
  - AC2 — features grid renders 2+ columns, no card overflow
  - AC3 — Pro Unlock cards sit 2+ per row, no card overflow
  - AC4 — hero heading/tagline/CTA inside the viewport, hero image dimmed (opacity < 1)
  - AC5 — hero and Pro Unlock CTAs ≥44px tall

ACs 1, 2, 3 and 5 were already satisfied by the existing responsive CSS; their tests were verified by temporarily breaking the production CSS (each test caught the break) and land as regression coverage, per the issue's "all ACs asserted by Playwright viewport tests" requirement. AC4 was genuinely red at 1180×820 before the fix.

## Test plan

- [x] Full Playwright suite green locally: 73 passed (includes AC6 — existing desktop 1280×800 and mobile 375×812 layout tests unchanged and passing)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)